### PR TITLE
feat: slide refresh token cookie validation

### DIFF
--- a/src/main/kotlin/com/tistory/shanepark/dutypark/member/controller/RefreshTokenController.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/member/controller/RefreshTokenController.kt
@@ -4,6 +4,7 @@ import com.tistory.shanepark.dutypark.member.domain.annotation.Login
 import com.tistory.shanepark.dutypark.member.service.RefreshTokenService
 import com.tistory.shanepark.dutypark.security.domain.dto.LoginMember
 import com.tistory.shanepark.dutypark.security.domain.dto.RefreshTokenDto
+import com.tistory.shanepark.dutypark.security.domain.entity.RefreshToken
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -16,7 +17,7 @@ class RefreshTokenController(
     @GetMapping
     fun findAllRefreshTokens(
         @Login loginMember: LoginMember,
-        @CookieValue("REFRESH_TOKEN", required = false) currentToken: String?,
+        @CookieValue(value = RefreshToken.cookieName, required = false) currentToken: String?,
         @RequestParam("validOnly", required = false, defaultValue = "true") validOnly: Boolean,
     ): List<RefreshTokenDto> {
         val refreshTokens = refreshTokenService.findRefreshTokens(loginMember.id, validOnly)

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/security/controller/AuthController.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/security/controller/AuthController.kt
@@ -6,6 +6,7 @@ import com.tistory.shanepark.dutypark.member.service.RefreshTokenService
 import com.tistory.shanepark.dutypark.security.config.JwtConfig
 import com.tistory.shanepark.dutypark.security.domain.dto.LoginDto
 import com.tistory.shanepark.dutypark.security.domain.dto.LoginMember
+import com.tistory.shanepark.dutypark.security.domain.entity.RefreshToken
 import com.tistory.shanepark.dutypark.security.service.AuthService
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
@@ -48,7 +49,7 @@ class AuthController(
                 .sameSite(SameSite.STRICT.name)
                 .build()
 
-            val refToken = ResponseCookie.from("REFRESH_TOKEN", refreshToken.token)
+            val refToken = ResponseCookie.from(RefreshToken.cookieName, refreshToken.token)
                 .httpOnly(true)
                 .path("/")
                 .secure(isSecure)

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
@@ -16,26 +16,26 @@ class RefreshTokenTest {
     }
 
     @Test
-    fun `validation update its remote Addr`() {
+    fun `slideValidUntil update its remote Addr`() {
         val refreshToken = RefreshToken(member, LocalDateTime.now().plusDays(1), "", "agent")
-        refreshToken.validation("127.0.0.1", "agent")
+        refreshToken.slideValidUntil("127.0.0.1", "agent")
 
         Assertions.assertThat(refreshToken.remoteAddr).isEqualTo("127.0.0.1")
     }
 
     @Test
-    fun `validation extends validUntil`() {
+    fun `slideValidUntil extends validUntil`() {
         val validUntil = LocalDateTime.now().plusDays(1)
         val refreshToken = RefreshToken(member, validUntil, "", "agent")
-        refreshToken.validation("", "agent")
+        refreshToken.slideValidUntil("", "agent")
 
         Assertions.assertThat(refreshToken.validUntil).isAfter(validUntil)
     }
 
     @Test
-    fun `validation updates userAgent`() {
+    fun `slideValidUntil updates userAgent`() {
         val refreshToken = RefreshToken(member, LocalDateTime.now().plusDays(1), "", "agent")
-        refreshToken.validation("", "agent2")
+        refreshToken.slideValidUntil("", "agent2")
 
         Assertions.assertThat(refreshToken.userAgent).isEqualTo("agent2")
     }


### PR DESCRIPTION
validation was extending when login succeed

but token cookie was not, which means "meaningless"

so updated it