### PR TITLE
feat: enable overview todo drag reorder

### DIFF
--- a/src/main/resources/static/css/base.css
+++ b/src/main/resources/static/css/base.css
@@ -741,11 +741,15 @@ a.homeButton:hover {
     align-items: center;
 }
 
-.todo-item .handle {
+.todo-item .handle,
+.todo-overview-item .handle {
     padding: 0.3rem;
     cursor: grab;
     font-size: 1.25rem;
     border-right: 1px solid #dee2e6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .todo-item:hover {

--- a/src/main/resources/static/js/duty/todo-list-methods.js
+++ b/src/main/resources/static/js/duty/todo-list-methods.js
@@ -49,14 +49,13 @@ const todoListMethods = {
       .then(([activeTodos, completedTodos]) => {
         this.todos = activeTodos;
         this.completedTodos = completedTodos;
+        this.todosLoading = false;
         this.$nextTick(() => {
           this.initSortable();
         });
       })
       .catch(() => {
         // Error already handled with alert.
-      })
-      .finally(() => {
         this.todosLoading = false;
       });
   }

--- a/src/main/resources/templates/duty/modals/todo-overview-modal.html
+++ b/src/main/resources/templates/duty/modals/todo-overview-modal.html
@@ -34,25 +34,37 @@
             </button>
           </div>
         </div>
-        <div v-if="filteredOverviewTodos.length > 0" class="list-group overflow-auto fs-3" style="max-height: 60vh;">
-          <div class="list-group-item todo-overview-item" v-for="todo in filteredOverviewTodos" :key="todo.id"
-               :class="{ 'completed': todo.status === 'COMPLETED' }">
-            <div class="row align-items-start g-3 flex-lg-nowrap">
-              <div class="col-8">
+        <div v-if="filteredOverviewTodos.length > 0" class="list-group overflow-auto fs-3" id="todo-overview-list"
+             style="max-height: 60vh;">
+          <div class="list-group-item todo-overview-item d-flex align-items-start gap-3"
+               v-for="todo in filteredOverviewTodos"
+               :key="todo.id"
+               :data-id="todo.id"
+               :class="{
+                 'completed': todo.status === 'COMPLETED',
+                 'todo-overview-item-active': todo.status === 'ACTIVE',
+                 'todo-overview-item-completed': todo.status === 'COMPLETED'
+               }">
+            <div v-if="todo.status === 'ACTIVE'"
+                 class="handle d-flex align-items-center justify-content-center flex-shrink-0">
+              <i class="bi bi-list"></i>
+            </div>
+            <div class="row align-items-start g-3 flex-lg-nowrap flex-grow-1 w-100">
+              <div class="col-lg-8 col-12">
                 <div class="fw-semibold" v-text="todo.title"></div>
                 <p class="mb-0 text-muted small" v-if="todo.content" v-text="sliceText(todo.content, 80)"></p>
               </div>
-              <div class="col-4">
-                <div class="todo-overview-meta d-flex flex-column align-items-end gap-2 text-muted small">
-                  <div class="d-flex align-items-center gap-1 justify-content-end">
+              <div class="col-lg-4 col-12">
+                <div class="todo-overview-meta d-flex flex-column align-items-lg-end align-items-start gap-2 text-muted small">
+                  <div class="d-flex align-items-center gap-1 justify-content-lg-end">
                     <i class="bi bi-pencil-square"></i>
                     <span :title="formatFullDateTime(todo.createdDate)">{{ formatSimpleDate(todo.createdDate) }}</span>
                   </div>
-                  <div class="d-flex align-items-center gap-1 justify-content-end" v-if="todo.completedDate">
+                  <div class="d-flex align-items-center gap-1 justify-content-lg-end" v-if="todo.completedDate">
                     <i class="bi bi-check-circle-fill"></i>
                     <span :title="formatFullDateTime(todo.completedDate)">{{ formatSimpleDate(todo.completedDate) }}</span>
                   </div>
-                  <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-end">
+                  <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-lg-end">
                     <button type="button" class="btn btn-outline-success btn-sm d-flex align-items-center gap-1"
                             v-if="todo.status === 'ACTIVE'"
                             v-on:click="completeTodoFromOverview(todo)">


### PR DESCRIPTION
## Summary
- allow dragging active todos inside overview modal with familiar handle
- sync reorder between overview and main list and persist order to backend

## Testing
- [x] Manual drag reorder in todo overview modal
- [x] Manual drag reorder in main todo bar