### PR TITLE
feat: show only active todos by default in overview

### DIFF
--- a/src/main/resources/static/js/duty/duty.js
+++ b/src/main/resources/static/js/duty/duty.js
@@ -55,7 +55,7 @@ function loadApp(memberId, teamId, loginMemberId, memberName, year, month, searc
         selectedTodoStatus: 'ACTIVE',
         todoOverviewFilters: {
           active: true,
-          completed: true,
+          completed: false,
         },
         loadDutyPromise: null,
         searchQuery: '',

--- a/src/main/resources/templates/duty/todo-list.html
+++ b/src/main/resources/templates/duty/todo-list.html
@@ -36,7 +36,7 @@
         <i class="bi bi-card-checklist"></i>
       </span>
       <span class="todo-overview-label d-none d-md-inline">Todo List</span>
-      <span class="todo-overview-count">{{ todos.length + completedTodos.length }}</span>
+      <span class="todo-overview-count">{{ todos.length }}</span>
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Show only active todos by default in the overview modal
- Update todo count badge to reflect only active todos

## Changes
- Set `todoOverviewFilters.completed` default to `false` in duty.js
- Update todo count display to show only active todos count

🤖 Generated with [Claude Code](https://claude.com/claude-code)