### PR TITLE
fix: improve time parsing logging and refresh token user agents

### DIFF
--- a/src/main/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/domain/ScheduleTimeParsingResponse.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/domain/ScheduleTimeParsingResponse.kt
@@ -8,4 +8,22 @@ data class ScheduleTimeParsingResponse(
     val content: String? = null,
     val errorMessage: String? = null,
     val rawResponse: String? = null,
-)
+) {
+    fun toLogMessage(request: ScheduleTimeParsingRequest): String {
+        return "date=${request.date}, content='${request.content}' -> '${contentForLog()}', " +
+                "time=${parsedTimeForLog()}, hasTime=$hasTime, result=$result"
+    }
+
+    private fun contentForLog(): String {
+        return content ?: "<null>"
+    }
+
+    private fun parsedTimeForLog(): String {
+        return when {
+            startDateTime == null && endDateTime == null -> "-"
+            startDateTime == null -> endDateTime!!
+            endDateTime == null || startDateTime == endDateTime -> startDateTime
+            else -> "$startDateTime ~ $endDateTime"
+        }
+    }
+}

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/service/ScheduleTimeParsingService.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/service/ScheduleTimeParsingService.kt
@@ -23,24 +23,30 @@ class ScheduleTimeParsingService(
     }
 
     fun parseScheduleTime(request: ScheduleTimeParsingRequest): ScheduleTimeParsingResponse {
-        if (!hasAnyTimeIndicator(request.content)) {
-            return ScheduleTimeParsingResponse(
+        val response = if (!hasAnyTimeIndicator(request.content)) {
+            ScheduleTimeParsingResponse(
                 result = true,
                 hasTime = false,
                 content = request.content
             )
+        } else {
+            parseScheduleTimeWithLlm(request)
         }
 
+        log.info("Time parsing result: {}", response.toLogMessage(request))
+        return response
+    }
+
+    private fun parseScheduleTimeWithLlm(request: ScheduleTimeParsingRequest): ScheduleTimeParsingResponse {
         val prompt = generatePrompt(request)
         val chatResponse = chatClient.prompt(prompt)
             .call()
             .chatResponse()
-        if (chatResponse == null) {
-            return ScheduleTimeParsingResponse(
+            ?: return ScheduleTimeParsingResponse(
                 result = false,
                 errorMessage = "LLM API returned null response"
             )
-        }
+
         val generation = chatResponse.results.firstOrNull()
         val chatAnswer = generation?.output?.text
         if (chatAnswer.isNullOrBlank()) {
@@ -49,9 +55,8 @@ class ScheduleTimeParsingService(
                 errorMessage = "LLM API returned empty response"
             )
         }
-        val response = parseChatAnswer(chatAnswer)
-        log.info("Time parsing result: request={}, hasTime={}, result={}", request, response.hasTime, response.result)
-        return response
+
+        return parseChatAnswer(chatAnswer)
     }
 
     private fun hasAnyTimeIndicator(content: String): Boolean {

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDto.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDto.kt
@@ -27,7 +27,7 @@ data class RefreshTokenDto(
                 remoteAddr = refreshToken.remoteAddr,
                 id = refreshToken.id!!,
                 token = refreshToken.token,
-                userAgent = UserAgentInfo.fromJson(refreshToken.userAgent),
+                userAgent = UserAgentInfo.fromStoredValue(refreshToken.userAgent),
             )
         }
     }

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/UserAgentInfo.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/UserAgentInfo.kt
@@ -45,5 +45,10 @@ data class UserAgentInfo(
                 null
             }
         }
+
+        fun fromStoredValue(value: String?): UserAgentInfo? {
+            if (value == null) return null
+            return fromJson(value) ?: parse(value)
+        }
     }
 }

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshToken.kt
@@ -76,7 +76,7 @@ class RefreshToken(
     private fun normalizeUserAgent(userAgent: String?): String? = userAgent?.take(USER_AGENT_MAX_LENGTH)
 
     companion object {
-        private const val USER_AGENT_MAX_LENGTH = 255
+        private const val USER_AGENT_MAX_LENGTH = 1024
     }
 
 }

--- a/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshToken.kt
@@ -3,7 +3,6 @@ package com.tistory.shanepark.dutypark.security.domain.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.tistory.shanepark.dutypark.common.domain.entity.BaseTimeEntity
 import com.tistory.shanepark.dutypark.member.domain.entity.Member
-import com.tistory.shanepark.dutypark.security.domain.dto.UserAgentInfo
 import jakarta.persistence.*
 import java.time.LocalDateTime
 import java.util.*
@@ -26,8 +25,8 @@ class RefreshToken(
 
     ) : BaseTimeEntity() {
 
-    @Column(name = "user_agent", nullable = true)
-    var userAgent: String? = UserAgentInfo.parse(userAgent)?.toJson()
+    @Column(name = "user_agent", nullable = true, length = USER_AGENT_MAX_LENGTH)
+    var userAgent: String? = normalizeUserAgent(userAgent)
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -71,7 +70,13 @@ class RefreshToken(
         validUntil = LocalDateTime.now().plusDays(validityDays)
         this.lastUsed = LocalDateTime.now()
         this.remoteAddr = remoteAddr
-        this.userAgent = UserAgentInfo.parse(userAgent)?.toJson()
+        this.userAgent = normalizeUserAgent(userAgent)
+    }
+
+    private fun normalizeUserAgent(userAgent: String?): String? = userAgent?.take(USER_AGENT_MAX_LENGTH)
+
+    companion object {
+        private const val USER_AGENT_MAX_LENGTH = 255
     }
 
 }

--- a/src/main/resources/db/migration/v2/V2.2.17__expand_refresh_token_user_agent.sql
+++ b/src/main/resources/db/migration/v2/V2.2.17__expand_refresh_token_user_agent.sql
@@ -1,0 +1,2 @@
+ALTER TABLE refresh_token
+    MODIFY COLUMN user_agent VARCHAR(1024) DEFAULT NULL;

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/member/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/member/service/RefreshTokenServiceTest.kt
@@ -25,6 +25,8 @@ import java.util.*
 class RefreshTokenServiceTest {
 
     private val fixedDateTime = LocalDateTime.of(2025, 1, 15, 12, 0, 0)
+    private val chromeUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
     @Mock
     private lateinit var memberRepository: MemberRepository
@@ -153,6 +155,20 @@ class RefreshTokenServiceTest {
         assertThat(result.remoteAddr).isEqualTo("127.0.0.1")
         verify(memberRepository).findById(1L)
         verify(refreshTokenRepository).save(any<RefreshToken>())
+    }
+
+    @Test
+    fun `createRefreshToken stores raw user agent without eager parsing`() {
+        val member = memberWithId(1L)
+        whenever(memberRepository.findById(1L)).thenReturn(Optional.of(member))
+        whenever(refreshTokenRepository.save(any<RefreshToken>())).thenAnswer { invocation ->
+            val token = invocation.getArgument<RefreshToken>(0)
+            refreshTokenWithIdFrom(1L, token)
+        }
+
+        val result = refreshTokenService.createRefreshToken(1L, "127.0.0.1", chromeUserAgent)
+
+        assertThat(result.userAgent).isEqualTo(chromeUserAgent)
     }
 
     private fun memberWithId(id: Long): Member {

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/service/ScheduleTimeParsingServiceResponseParsingTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/schedule/timeparsing/service/ScheduleTimeParsingServiceResponseParsingTest.kt
@@ -1,14 +1,19 @@
 package com.tistory.shanepark.dutypark.schedule.timeparsing.service
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.tistory.shanepark.dutypark.TestUtils.Companion.jsr310JsonMapper
 import com.tistory.shanepark.dutypark.schedule.timeparsing.domain.ScheduleTimeParsingRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
@@ -21,11 +26,19 @@ class ScheduleTimeParsingServiceResponseParsingTest {
 
     private lateinit var chatModel: ChatModel
     private lateinit var service: ScheduleTimeParsingService
+    private lateinit var logAppender: ListAppender<ILoggingEvent>
 
     @BeforeEach
     fun setup() {
         chatModel = mock()
         service = ScheduleTimeParsingService(chatModel, jsr310JsonMapper())
+        logAppender = ListAppender<ILoggingEvent>().apply { start() }
+        serviceLogger().addAppender(logAppender)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        serviceLogger().detachAppender(logAppender)
     }
 
     @Test
@@ -110,6 +123,35 @@ class ScheduleTimeParsingServiceResponseParsingTest {
     }
 
     @Test
+    fun `parseScheduleTime logs content before and after with parsed time`() {
+        whenever(chatModel.call(any<Prompt>())).thenReturn(
+            ChatResponse(
+                listOf(
+                    Generation(
+                        AssistantMessage(
+                            """{"result":true,"hasTime":true,"startDateTime":"2025-02-28T17:20:00","endDateTime":"2025-02-28T17:20:00","content":"이재상담"}"""
+                        )
+                    )
+                )
+            )
+        )
+
+        service.parseScheduleTime(
+            ScheduleTimeParsingRequest(
+                date = LocalDate.of(2025, 2, 28),
+                content = "이재상담5시20분"
+            )
+        )
+
+        val logMessage = logAppender.list.last().formattedMessage
+
+        assertThat(logMessage).contains("content='이재상담5시20분' -> '이재상담'")
+        assertThat(logMessage).contains("time=2025-02-28T17:20:00")
+        assertThat(logMessage).contains("hasTime=true")
+        assertThat(logMessage).contains("result=true")
+    }
+
+    @Test
     fun `parseScheduleTime returns failure when generation is empty`() {
         whenever(chatModel.call(any<Prompt>())).thenReturn(ChatResponse(emptyList()))
 
@@ -122,5 +164,9 @@ class ScheduleTimeParsingServiceResponseParsingTest {
 
         assertThat(response.result).isFalse()
         assertThat(response.errorMessage).isEqualTo("LLM API returned empty response")
+    }
+
+    private fun serviceLogger(): Logger {
+        return LoggerFactory.getLogger(ScheduleTimeParsingService::class.java) as Logger
     }
 }

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
@@ -10,7 +10,6 @@ class RefreshTokenDtoTest {
 
     private val chromeUserAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-
     @Test
     fun `of parses raw user agent values`() {
         val refreshToken = refreshToken(userAgent = chromeUserAgent)
@@ -33,23 +32,27 @@ class RefreshTokenDtoTest {
     }
 
     private fun refreshToken(userAgent: String?): RefreshToken {
-        val member = Member(name = "tester", email = "tester@duty.park", password = "secret")
-        val memberIdField = Member::class.java.getDeclaredField("id")
-        memberIdField.isAccessible = true
-        memberIdField.set(member, 1L)
+        val member = member()
 
         val refreshToken = RefreshToken(
             member = member,
             validUntil = LocalDateTime.now().plusDays(1),
             remoteAddr = "127.0.0.1",
-            userAgent = null
+            userAgent = userAgent
         )
-        refreshToken.userAgent = userAgent
 
         val tokenIdField = RefreshToken::class.java.getDeclaredField("id")
         tokenIdField.isAccessible = true
         tokenIdField.set(refreshToken, 1L)
 
         return refreshToken
+    }
+
+    private fun member(): Member {
+        val member = Member(name = "tester", email = "tester@duty.park", password = "secret")
+        val memberIdField = Member::class.java.getDeclaredField("id")
+        memberIdField.isAccessible = true
+        memberIdField.set(member, 1L)
+        return member
     }
 }

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
@@ -1,0 +1,55 @@
+package com.tistory.shanepark.dutypark.security.domain.dto
+
+import com.tistory.shanepark.dutypark.member.domain.entity.Member
+import com.tistory.shanepark.dutypark.security.domain.entity.RefreshToken
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class RefreshTokenDtoTest {
+
+    private val chromeUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+    @Test
+    fun `of parses raw user agent values`() {
+        val refreshToken = refreshToken(userAgent = chromeUserAgent)
+
+        val result = RefreshTokenDto.of(refreshToken)
+
+        assertThat(result.userAgent?.browser).isEqualTo("Chrome")
+        assertThat(result.userAgent?.os).isEqualTo("Windows NT")
+    }
+
+    @Test
+    fun `of keeps supporting legacy json user agent values`() {
+        val legacyJson = UserAgentInfo.parse(chromeUserAgent)?.toJson()
+        val refreshToken = refreshToken(userAgent = legacyJson)
+
+        val result = RefreshTokenDto.of(refreshToken)
+
+        assertThat(result.userAgent?.browser).isEqualTo("Chrome")
+        assertThat(result.userAgent?.os).isEqualTo("Windows NT")
+    }
+
+    private fun refreshToken(userAgent: String?): RefreshToken {
+        val member = Member(name = "tester", email = "tester@duty.park", password = "secret")
+        val memberIdField = Member::class.java.getDeclaredField("id")
+        memberIdField.isAccessible = true
+        memberIdField.set(member, 1L)
+
+        val refreshToken = RefreshToken(
+            member = member,
+            validUntil = LocalDateTime.now().plusDays(1),
+            remoteAddr = "127.0.0.1",
+            userAgent = null
+        )
+        refreshToken.userAgent = userAgent
+
+        val tokenIdField = RefreshToken::class.java.getDeclaredField("id")
+        tokenIdField.isAccessible = true
+        tokenIdField.set(refreshToken, 1L)
+
+        return refreshToken
+    }
+}

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/dto/RefreshTokenDtoTest.kt
@@ -10,6 +10,13 @@ class RefreshTokenDtoTest {
 
     private val chromeUserAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    private val longAndroidChromeUserAgent =
+        "Mozilla/5.0 (" +
+                "DutyParkApp/6.0; ".repeat(18) +
+                "Linux; Android 14; Pixel 8 Pro) " +
+                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/122.0.0.0 Mobile Safari/537.36"
+
     @Test
     fun `of parses raw user agent values`() {
         val refreshToken = refreshToken(userAgent = chromeUserAgent)
@@ -18,6 +25,18 @@ class RefreshTokenDtoTest {
 
         assertThat(result.userAgent?.browser).isEqualTo("Chrome")
         assertThat(result.userAgent?.os).isEqualTo("Windows NT")
+    }
+
+    @Test
+    fun `of preserves browser and device for user agents longer than legacy 255 limit`() {
+        val refreshToken = refreshToken(userAgent = longAndroidChromeUserAgent)
+
+        val result = RefreshTokenDto.of(refreshToken)
+
+        assertThat(longAndroidChromeUserAgent.length).isGreaterThan(255)
+        assertThat(result.userAgent?.os).isEqualTo("Android")
+        assertThat(result.userAgent?.browser).isEqualTo("Chrome")
+        assertThat(result.userAgent?.device).isEqualTo("Android Mobile")
     }
 
     @Test

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
@@ -17,6 +17,7 @@ class RefreshTokenTest {
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     private val firefoxUserAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0"
+    private val longUserAgent = "dp-test-" + "x".repeat(320)
 
     init {
         member.team = team
@@ -55,6 +56,13 @@ class RefreshTokenTest {
         val refreshToken = RefreshToken(member, fixedDateTime.plusDays(1), "", chromeUserAgent)
 
         Assertions.assertThat(refreshToken.userAgent).isEqualTo(chromeUserAgent)
+    }
+
+    @Test
+    fun `refresh token keeps userAgent longer than legacy 255 limit`() {
+        val refreshToken = RefreshToken(member, fixedDateTime.plusDays(1), "", longUserAgent)
+
+        Assertions.assertThat(refreshToken.userAgent).isEqualTo(longUserAgent)
     }
 
 }

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/domain/entity/RefreshTokenTest.kt
@@ -47,7 +47,14 @@ class RefreshTokenTest {
         refreshToken.slideValidUntil("", firefoxUserAgent, 7)
 
         Assertions.assertThat(refreshToken.userAgent).isNotEqualTo(originalUserAgent)
-        Assertions.assertThat(refreshToken.userAgent).contains("Firefox")
+        Assertions.assertThat(refreshToken.userAgent).isEqualTo(firefoxUserAgent)
+    }
+
+    @Test
+    fun `refresh token stores raw userAgent without eager parsing`() {
+        val refreshToken = RefreshToken(member, fixedDateTime.plusDays(1), "", chromeUserAgent)
+
+        Assertions.assertThat(refreshToken.userAgent).isEqualTo(chromeUserAgent)
     }
 
 }

--- a/src/test/kotlin/com/tistory/shanepark/dutypark/security/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/tistory/shanepark/dutypark/security/service/AuthServiceTest.kt
@@ -40,6 +40,10 @@ class AuthServiceTest {
     private val fixedDateTime = LocalDateTime.of(2025, 1, 15, 12, 0, 0)
     private val futureDateTime = LocalDateTime.now().plusDays(30)
     private val pastDateTime = LocalDateTime.now().minusDays(1)
+    private val chromeUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    private val firefoxUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0"
 
     private val memberRepository: MemberRepository = mock()
     private val memberSsoRegisterRepository: MemberSsoRegisterRepository = mock()
@@ -221,18 +225,19 @@ class AuthServiceTest {
             member = member,
             validUntil = futureDateTime,
             remoteAddr = "127.0.0.1",
-            userAgent = null
+            userAgent = chromeUserAgent
         )
         val before = refreshToken.validUntil
         whenever(refreshTokenService.findByToken("valid")).thenReturn(refreshToken)
         whenever(jwtProvider.createToken(member)).thenReturn("new-jwt")
-        val request = requestWith("127.0.0.1", "user@duty.park")
+        val request = requestWith("127.0.0.1", firefoxUserAgent)
 
         val result = authService.refreshAccessToken("valid", request)
 
         assertThat(result.accessToken).isEqualTo("new-jwt")
         assertThat(result.refreshToken).isEqualTo(refreshToken.token)
         assertThat(refreshToken.validUntil).isAfter(before)
+        assertThat(refreshToken.userAgent).isEqualTo(firefoxUserAgent)
     }
 
     @Test
@@ -283,10 +288,10 @@ class AuthServiceTest {
         }
     }
 
-    private fun requestWith(ip: String, email: String): MockHttpServletRequest {
+    private fun requestWith(ip: String, userAgent: String = "test-agent"): MockHttpServletRequest {
         val request = MockHttpServletRequest()
         request.remoteAddr = ip
-        request.addHeader(HttpHeaders.USER_AGENT, "test-agent")
+        request.addHeader(HttpHeaders.USER_AGENT, userAgent)
         return request
     }
 


### PR DESCRIPTION
## Summary
- add richer schedule time parsing logs with request, normalized content, and parsed time details
- preserve refresh token user agent metadata by keeping raw values, widening storage, and covering long user agents in tests

## Changes
- Schedule time parsing
  - add a response helper that formats request and parsing results into a single log line
  - log both no-time and LLM parsing paths after the final response is built
  - cover the new logging output with response parsing tests
- Refresh tokens
  - stop eagerly serializing parsed user agents before persistence
  - support both raw and legacy JSON user agent values when building refresh token DTOs
  - expand the `refresh_token.user_agent` column to 1024 characters to preserve longer raw headers
  - add regression coverage for long raw user agents through the DTO parsing path
  - extend refresh token and auth tests around storage and refresh flows

## Commits
- 283a2209 test: cover long refresh token user agents
- d3661c59 fix: expand refresh token user agent storage
- 369d73a3 fix: defer refresh token user agent parsing
- 4024271d fix: improve schedule time parsing logs

## Verification
- [ ] Build check (post-PR)
