### PR TITLE
fix: Show identical schedule times once

### DIFF
--- a/frontend/src/components/duty/ScheduleList.vue
+++ b/frontend/src/components/duty/ScheduleList.vue
@@ -153,6 +153,9 @@ function formatScheduleTime(schedule: Schedule) {
   if (startTime === '00:00' && endTime === '00:00') {
     return ''
   }
+  if (startTime === endTime) {
+    return `(${startTime})`
+  }
   if (startTime !== '00:00' && endTime === '00:00') {
     return `(${startTime})`
   }


### PR DESCRIPTION
## Summary
- Updates schedule detail display so identical start and end times are shown once.
- Keeps midnight-only schedules hidden as before.

## Changes
- Frontend: add a same-time guard in `ScheduleList.vue` before rendering a time range.

## Commits
- f1a1e2ca fix: Show identical schedule times once

## Verification
- [ ] Build check (post-PR)