### PR TITLE
feat: improve calendar navigation and notification reads

### DIFF
--- a/frontend/src/components/common/CalendarMonthNavigator.vue
+++ b/frontend/src/components/common/CalendarMonthNavigator.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
+
+defineProps<{
+  currentYear: number
+  currentMonth: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'prev-month'): void
+  (e: 'next-month'): void
+  (e: 'open-year-month-picker'): void
+}>()
+
+const { t } = useI18n()
+
+const MONTH_SWIPE_THRESHOLD = 44
+const MONTH_SWIPE_VERTICAL_TOLERANCE = 28
+
+let monthTouchStartX = 0
+let monthTouchStartY = 0
+let monthTouchLastX = 0
+let monthTouchLastY = 0
+let isMonthTouching = false
+let suppressMonthPickerClick = false
+let suppressClickTimer: number | null = null
+
+function resetMonthTouch() {
+  monthTouchStartX = 0
+  monthTouchStartY = 0
+  monthTouchLastX = 0
+  monthTouchLastY = 0
+  isMonthTouching = false
+}
+
+function scheduleSuppressClickReset() {
+  if (suppressClickTimer !== null) {
+    window.clearTimeout(suppressClickTimer)
+  }
+
+  suppressClickTimer = window.setTimeout(() => {
+    suppressMonthPickerClick = false
+    suppressClickTimer = null
+  }, 250)
+}
+
+function handleMonthTouchStart(event: TouchEvent) {
+  const touch = event.touches[0]
+  if (!touch) return
+
+  monthTouchStartX = touch.clientX
+  monthTouchStartY = touch.clientY
+  monthTouchLastX = touch.clientX
+  monthTouchLastY = touch.clientY
+  isMonthTouching = true
+}
+
+function handleMonthTouchMove(event: TouchEvent) {
+  if (!isMonthTouching) return
+
+  const touch = event.touches[0]
+  if (!touch) return
+
+  monthTouchLastX = touch.clientX
+  monthTouchLastY = touch.clientY
+}
+
+function handleMonthTouchEnd(event: TouchEvent) {
+  if (!isMonthTouching) return
+
+  const touch = event.changedTouches[0]
+  const endX = touch?.clientX ?? monthTouchLastX
+  const endY = touch?.clientY ?? monthTouchLastY
+  const deltaX = endX - monthTouchStartX
+  const deltaY = Math.abs(endY - monthTouchStartY)
+  const isHorizontalSwipe =
+    Math.abs(deltaX) >= MONTH_SWIPE_THRESHOLD &&
+    Math.abs(deltaX) > deltaY + MONTH_SWIPE_VERTICAL_TOLERANCE
+
+  resetMonthTouch()
+
+  if (!isHorizontalSwipe) return
+
+  if (event.cancelable) {
+    event.preventDefault()
+  }
+  event.stopPropagation()
+  suppressMonthPickerClick = true
+
+  if (deltaX > 0) {
+    emit('prev-month')
+  } else {
+    emit('next-month')
+  }
+
+  scheduleSuppressClickReset()
+}
+
+function handleMonthButtonClick(event: MouseEvent) {
+  if (suppressMonthPickerClick) {
+    event.preventDefault()
+    event.stopPropagation()
+    suppressMonthPickerClick = false
+    return
+  }
+
+  emit('open-year-month-picker')
+}
+
+onBeforeUnmount(() => {
+  if (suppressClickTimer !== null) {
+    window.clearTimeout(suppressClickTimer)
+  }
+})
+</script>
+
+<template>
+  <div class="flex items-center justify-center">
+    <button
+      type="button"
+      @click="emit('prev-month')"
+      class="calendar-nav-btn flex min-h-11 min-w-11 flex-shrink-0 cursor-pointer items-center justify-center rounded-full p-1 sm:p-2"
+      :aria-label="t('common.calendar.previousMonth')"
+    >
+      <ChevronLeft class="h-5 w-5 sm:h-6 sm:w-6" />
+    </button>
+    <button
+      type="button"
+      @click="handleMonthButtonClick"
+      @touchstart.passive="handleMonthTouchStart"
+      @touchmove.passive="handleMonthTouchMove"
+      @touchend="handleMonthTouchEnd"
+      @touchcancel="resetMonthTouch"
+      class="calendar-nav-btn flex min-h-11 min-w-[5.5rem] touch-pan-y select-none items-center justify-center whitespace-nowrap rounded px-1 py-1 text-lg font-semibold cursor-pointer sm:min-w-[6.75rem] sm:px-3 sm:text-2xl"
+    >
+      {{ currentYear }}-{{ String(currentMonth).padStart(2, '0') }}
+    </button>
+    <button
+      type="button"
+      @click="emit('next-month')"
+      class="calendar-nav-btn flex min-h-11 min-w-11 flex-shrink-0 cursor-pointer items-center justify-center rounded-full p-1 sm:p-2"
+      :aria-label="t('common.calendar.nextMonth')"
+    >
+      <ChevronRight class="h-5 w-5 sm:h-6 sm:w-6" />
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/common/NotificationBell.vue
+++ b/frontend/src/components/common/NotificationBell.vue
@@ -13,20 +13,45 @@ const notificationStore = useNotificationStore()
 const authStore = useAuthStore()
 const { t } = useI18n()
 const isDropdownVisible = ref(false)
+let singleUnreadToMarkOnCloseId: string | null = null
 
-function toggleDropdown() {
-  isDropdownVisible.value = !isDropdownVisible.value
-  emit('toggle', isDropdownVisible.value)
-
-  // Fetch recent notifications when opening dropdown
-  if (isDropdownVisible.value) {
-    notificationStore.fetchRecentNotifications()
+async function refreshDropdownNotifications() {
+  singleUnreadToMarkOnCloseId = null
+  const loaded = await notificationStore.fetchRecentNotifications()
+  if (!loaded || !isDropdownVisible.value) {
+    return
   }
+
+  singleUnreadToMarkOnCloseId = notificationStore.getSingleUnreadRecentNotificationId()
+}
+
+function openDropdown() {
+  isDropdownVisible.value = true
+  emit('toggle', true)
+  void refreshDropdownNotifications()
 }
 
 function closeDropdown() {
-  isDropdownVisible.value = false
-  emit('toggle', false)
+  const notificationId = singleUnreadToMarkOnCloseId
+  singleUnreadToMarkOnCloseId = null
+
+  if (isDropdownVisible.value) {
+    isDropdownVisible.value = false
+    emit('toggle', false)
+  }
+
+  if (notificationId) {
+    void notificationStore.markSingleUnreadAsRead(notificationId)
+  }
+}
+
+function toggleDropdown() {
+  if (isDropdownVisible.value) {
+    closeDropdown()
+    return
+  }
+
+  openDropdown()
 }
 
 // Expose close method for parent component
@@ -39,6 +64,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  singleUnreadToMarkOnCloseId = null
   notificationStore.stopPolling()
 })
 </script>

--- a/frontend/src/components/duty/DayDetailModal.vue
+++ b/frontend/src/components/duty/DayDetailModal.vue
@@ -490,7 +490,7 @@ function handleUploadError(message: string) {
               :disabled="isUploading"
               class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             >
-              {{ isUploading ? t('duty.common.uploading') : (isEditMode ? t('duty.schedule.actions.edit') : t('duty.schedule.actions.save')) }}
+              {{ isUploading ? t('duty.common.uploading') : t('duty.schedule.actions.save') }}
             </button>
           </div>
         </div>

--- a/frontend/src/components/duty/DutyHeaderControls.vue
+++ b/frontend/src/components/duty/DutyHeaderControls.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ChevronLeft, ChevronRight, Search } from 'lucide-vue-next'
+import { Search } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
+import CalendarMonthNavigator from '@/components/common/CalendarMonthNavigator.vue'
 import ProfileAvatar from '@/components/common/ProfileAvatar.vue'
 
 const props = defineProps<{
@@ -53,20 +54,13 @@ function handleSearchClick() {
     </div>
 
     <!-- Center: Year-Month Navigation -->
-    <div class="flex items-center justify-center">
-      <button @click="emit('prev-month')" class="calendar-nav-btn p-0.5 sm:p-2 rounded-full flex items-center justify-center flex-shrink-0 cursor-pointer">
-        <ChevronLeft class="w-5 h-5 sm:w-6 sm:h-6" />
-      </button>
-      <button
-        @click="emit('open-year-month-picker')"
-        class="calendar-nav-btn px-1 sm:px-3 py-1 text-lg sm:text-2xl font-semibold rounded whitespace-nowrap cursor-pointer"
-      >
-        {{ currentYear }}-{{ String(currentMonth).padStart(2, '0') }}
-      </button>
-      <button @click="emit('next-month')" class="calendar-nav-btn p-0.5 sm:p-2 rounded-full flex items-center justify-center flex-shrink-0 cursor-pointer">
-        <ChevronRight class="w-5 h-5 sm:w-6 sm:h-6" />
-      </button>
-    </div>
+    <CalendarMonthNavigator
+      :current-year="currentYear"
+      :current-month="currentMonth"
+      @prev-month="emit('prev-month')"
+      @next-month="emit('next-month')"
+      @open-year-month-picker="emit('open-year-month-picker')"
+    />
 
     <!-- Right: Search -->
     <div class="flex min-w-0 justify-end">

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -266,6 +266,8 @@ export default {
     calendar: {
       previousYear: 'Previous year',
       nextYear: 'Next year',
+      previousMonth: 'Previous month',
+      nextMonth: 'Next month',
       yearLabel: '{year}',
       thisMonth: 'This month ({date})',
     },

--- a/frontend/src/i18n/messages/es.ts
+++ b/frontend/src/i18n/messages/es.ts
@@ -266,6 +266,8 @@ export default {
     calendar: {
       previousYear: 'año anterior',
       nextYear: 'el año que viene',
+      previousMonth: 'Mes anterior',
+      nextMonth: 'Mes siguiente',
       yearLabel: '{year}',
       thisMonth: 'Este mes ({date})',
     },

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -274,6 +274,8 @@ export default {
       ...en.common.calendar,
       previousYear: '前年',
       nextYear: '翌年',
+      previousMonth: '前月',
+      nextMonth: '翌月',
       yearLabel: '{year}年',
       thisMonth: '今月 ({date})',
     },

--- a/frontend/src/i18n/messages/ko.ts
+++ b/frontend/src/i18n/messages/ko.ts
@@ -266,6 +266,8 @@ export default {
     calendar: {
       previousYear: '이전 연도',
       nextYear: '다음 연도',
+      previousMonth: '이전 월',
+      nextMonth: '다음 월',
       yearLabel: '{year}년',
       thisMonth: '이번달 ({date})',
     },

--- a/frontend/src/i18n/messages/zh.ts
+++ b/frontend/src/i18n/messages/zh.ts
@@ -266,6 +266,8 @@ export default {
     calendar: {
       previousYear: '上一年',
       nextYear: '明年',
+      previousMonth: '上个月',
+      nextMonth: '下个月',
       yearLabel: '{year}',
       thisMonth: '本月 ({date})',
     },

--- a/frontend/src/stores/notification.test.ts
+++ b/frontend/src/stores/notification.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { notificationApi } from '@/api/notification'
+import type { NotificationDto } from '@/types'
+
+vi.mock('@/api/notification', () => ({
+  notificationApi: {
+    markAsRead: vi.fn(),
+  },
+}))
+
+function createNotification(id: string, isRead = false): NotificationDto {
+  return {
+    id,
+    type: 'FRIEND_REQUEST_RECEIVED',
+    referenceType: 'FRIEND_REQUEST',
+    referenceId: 'friend-request-id',
+    actorId: 1,
+    payload: {
+      version: 1,
+      actor: {
+        name: 'Tester',
+        hasProfilePhoto: false,
+        profilePhotoVersion: 0,
+      },
+    },
+    isRead,
+    createdAt: '2026-05-10T00:00:00Z',
+  }
+}
+
+describe('notification store', async () => {
+  const { useNotificationStore } = await import('./notification')
+  const markAsRead = vi.mocked(notificationApi.markAsRead)
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {},
+      configurable: true,
+    })
+    setActivePinia(createPinia())
+    markAsRead.mockReset()
+  })
+
+  it('marks the only unread notification as read', async () => {
+    const unreadNotification = createNotification('notification-1')
+    const readNotification = createNotification('notification-2', true)
+    const store = useNotificationStore()
+    store.unreadCount = 1
+    store.recentNotifications = [unreadNotification, readNotification]
+    markAsRead.mockResolvedValue({ ...unreadNotification, isRead: true })
+
+    await store.markSingleUnreadAsRead()
+
+    expect(markAsRead).toHaveBeenCalledWith('notification-1')
+    expect(store.unreadCount).toBe(0)
+    expect(store.recentNotifications[0]?.isRead).toBe(true)
+  })
+
+  it('does not mark a different single unread notification than the one captured on open', async () => {
+    const store = useNotificationStore()
+    store.unreadCount = 1
+    store.recentNotifications = [createNotification('notification-2')]
+
+    await store.markSingleUnreadAsRead('notification-1')
+
+    expect(markAsRead).not.toHaveBeenCalled()
+    expect(store.unreadCount).toBe(1)
+  })
+
+  it('does not auto-read when multiple notifications are unread', async () => {
+    const store = useNotificationStore()
+    store.unreadCount = 2
+    store.recentNotifications = [
+      createNotification('notification-1'),
+      createNotification('notification-2'),
+    ]
+
+    await store.markSingleUnreadAsRead()
+
+    expect(markAsRead).not.toHaveBeenCalled()
+    expect(store.unreadCount).toBe(2)
+  })
+})

--- a/frontend/src/stores/notification.ts
+++ b/frontend/src/stores/notification.ts
@@ -173,15 +173,17 @@ export const useNotificationStore = defineStore('notification', () => {
   /**
    * Fetch recent notifications (read + unread) for dropdown
    */
-  async function fetchRecentNotifications(): Promise<void> {
+  async function fetchRecentNotifications(): Promise<boolean> {
     isLoading.value = true
     try {
       const page = await notificationApi.getNotifications(0, 10)
       recentNotifications.value = page.content
       consecutiveFailures.value = 0
+      return true
     } catch (error) {
       consecutiveFailures.value++
       console.warn('Failed to fetch recent notifications:', error)
+      return false
     } finally {
       isLoading.value = false
     }
@@ -211,6 +213,34 @@ export const useNotificationStore = defineStore('notification', () => {
     } catch (error) {
       console.error('Failed to mark notification as read:', error)
       throw error
+    }
+  }
+
+  function getSingleUnreadRecentNotificationId(): string | null {
+    if (unreadCount.value !== 1) {
+      return null
+    }
+
+    const unreadRecentNotifications = recentNotifications.value.filter(n => !n.isRead)
+    const [notification] = unreadRecentNotifications
+
+    return unreadRecentNotifications.length === 1 && notification ? notification.id : null
+  }
+
+  /**
+   * Mark the single unread notification as read when the dropdown itself is the confirmation.
+   */
+  async function markSingleUnreadAsRead(expectedId?: string): Promise<void> {
+    const notificationId = getSingleUnreadRecentNotificationId()
+
+    if (!notificationId || (expectedId && notificationId !== expectedId)) {
+      return
+    }
+
+    try {
+      await markAsRead(notificationId)
+    } catch {
+      // markAsRead already logs the failure; dropdown visibility should not be blocked.
     }
   }
 
@@ -358,6 +388,8 @@ export const useNotificationStore = defineStore('notification', () => {
     fetchUnreadNotifications,
     fetchRecentNotifications,
     markAsRead,
+    getSingleUnreadRecentNotificationId,
+    markSingleUnreadAsRead,
     markAllAsRead,
     startPolling,
     stopPolling,

--- a/frontend/src/views/team/TeamView.vue
+++ b/frontend/src/views/team/TeamView.vue
@@ -3,8 +3,6 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import {
-  ChevronLeft,
-  ChevronRight,
   Settings,
   CalendarPlus,
   Pencil,
@@ -20,6 +18,7 @@ import { dutyApi } from '@/api/duty'
 import { useSwal } from '@/composables/useSwal'
 import { isLightColor } from '@/utils/color'
 import BaseModal from '@/components/common/BaseModal.vue'
+import CalendarMonthNavigator from '@/components/common/CalendarMonthNavigator.vue'
 import YearMonthPicker from '@/components/common/YearMonthPicker.vue'
 import CharacterCounter from '@/components/common/CharacterCounter.vue'
 import CalendarGrid from '@/components/common/CalendarGrid.vue'
@@ -426,20 +425,13 @@ onMounted(() => {
         </div>
 
         <!-- Center: Year-Month Navigation -->
-        <div class="flex items-center justify-center">
-          <button @click="prevMonth" class="calendar-nav-btn p-1 sm:p-2 rounded-full flex items-center justify-center flex-shrink-0 cursor-pointer">
-            <ChevronLeft class="w-5 h-5 sm:w-6 sm:h-6" />
-          </button>
-          <button
-            @click="isYearMonthPickerOpen = true"
-            class="calendar-nav-btn px-2 sm:px-3 py-1 text-lg sm:text-2xl font-semibold rounded whitespace-nowrap cursor-pointer"
-          >
-            {{ currentYear }}-{{ String(currentMonth).padStart(2, '0') }}
-          </button>
-          <button @click="nextMonth" class="calendar-nav-btn p-1 sm:p-2 rounded-full flex items-center justify-center flex-shrink-0 cursor-pointer">
-            <ChevronRight class="w-5 h-5 sm:w-6 sm:h-6" />
-          </button>
-        </div>
+        <CalendarMonthNavigator
+          :current-year="currentYear"
+          :current-month="currentMonth"
+          @prev-month="prevMonth"
+          @next-month="nextMonth"
+          @open-year-month-picker="isYearMonthPickerOpen = true"
+        />
 
         <!-- Right: Team manage button -->
         <div class="flex-shrink-0">


### PR DESCRIPTION
## Summary
- Add reusable month navigation with swipe gestures for calendar headers.
- Mark the single unread dropdown notification as read when the dropdown is closed.
- Label schedule edit submissions as save actions.

## Changes
- Calendar: add `CalendarMonthNavigator` and reuse it in duty and team calendar headers with previous/next controls and year-month picker access.
- Notifications: refresh dropdown notifications on open, capture the single unread notification id, and mark it read on close only when it is still the same single unread item.
- Copy and tests: add calendar aria-label translations and Pinia coverage for single-unread notification read behavior.

## Commits
- 5d2401d2 fix: mark single notification read on close
- 5d90f484 fix: label schedule edit submit as save
- b8ce3c16 feat: add swipe month navigation to calendars

## Verification
- [ ] Build check (post-PR)
