### PR TITLE
fix: Disable invalid modal submissions

### DIFF
--- a/.github/scripts/prepare-github-release.mjs
+++ b/.github/scripts/prepare-github-release.mjs
@@ -139,7 +139,7 @@ function releaseNotesFromInAppEntry(note, pr) {
 ${changes}
 
 ## Pull Request
-- #${pr.number} ${pr.url}
+- [#${pr.number}](${pr.url})
 `
 }
 

--- a/frontend/src/components/common/FriendSearchModal.vue
+++ b/frontend/src/components/common/FriendSearchModal.vue
@@ -70,7 +70,8 @@ function handleKeywordInput(event: Event) {
           />
         </div>
         <button
-          class="flex-shrink-0 px-4 sm:px-5 py-3 bg-gradient-to-r from-dp-surface-strong to-dp-surface-strong-alt text-dp-text-on-dark rounded-xl hover:from-dp-surface-strong-alt hover:to-dp-surface-strong-hover transition-all shadow-lg flex items-center gap-2 font-medium cursor-pointer whitespace-nowrap"
+          class="flex-shrink-0 px-4 sm:px-5 py-3 bg-gradient-to-r from-dp-surface-strong to-dp-surface-strong-alt text-dp-text-on-dark rounded-xl hover:from-dp-surface-strong-alt hover:to-dp-surface-strong-hover transition-all shadow-lg flex items-center gap-2 font-medium cursor-pointer whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="!keyword.trim() || loading"
           @click="emit('search')"
         >
           <Search class="w-4 h-4" />

--- a/frontend/src/components/common/ImageCropModal.vue
+++ b/frontend/src/components/common/ImageCropModal.vue
@@ -144,7 +144,7 @@ function handleConfirm() {
 
   const result = cropperRef.value?.getResult()
   if (!result?.canvas) {
-    emit('close')
+    showError(t('imageCropModal.cropFailed'))
     return
   }
 
@@ -154,7 +154,7 @@ function handleConfirm() {
     (blob) => {
       if (!blob) {
         isProcessing.value = false
-        emit('close')
+        showError(t('imageCropModal.cropFailed'))
         return
       }
 

--- a/frontend/src/components/duty/DDayModal.vue
+++ b/frontend/src/components/duty/DDayModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { X, Plus, Minus, RotateCcw, Lock, Unlock } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import BaseModal from '@/components/common/BaseModal.vue'
@@ -32,6 +32,9 @@ const { t } = useI18n()
 const title = ref('')
 const date = ref('')
 const isPrivate = ref(false)
+
+const isTitleMissing = computed(() => !title.value.trim())
+const isDateMissing = computed(() => !date.value)
 
 watch(
   () => props.isOpen,
@@ -109,6 +112,7 @@ const isEditMode = props.dday !== null && props.dday !== undefined
           maxlength="30"
           class="form-control"
           :placeholder="t('duty.ddayModal.placeholders.title')"
+          :aria-invalid="isTitleMissing"
         />
       </div>
 
@@ -120,6 +124,7 @@ const isEditMode = props.dday !== null && props.dday !== undefined
           v-model="date"
           type="date"
           class="form-control"
+          :aria-invalid="isDateMissing"
         />
       </div>
 
@@ -191,7 +196,7 @@ const isEditMode = props.dday !== null && props.dday !== undefined
       </button>
       <button
         @click="handleSave"
-        :disabled="!title.trim() || !date"
+        :disabled="isTitleMissing || isDateMissing"
         class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
       >
         {{ t('duty.ddayModal.save') }}

--- a/frontend/src/components/duty/DayDetailModal.vue
+++ b/frontend/src/components/duty/DayDetailModal.vue
@@ -189,6 +189,16 @@ const visibilityOptions = computed(() => [
   },
 ])
 
+const isScheduleTitleMissing = computed(() => !newSchedule.value.content.trim())
+const isScheduleTimeRangeInvalid = computed(() => {
+  const { startDateTime, endDateTime } = newSchedule.value
+  if (!startDateTime || !endDateTime) return false
+  return endDateTime < startDateTime
+})
+const isScheduleSaveDisabled = computed(() =>
+  isScheduleTitleMissing.value || isScheduleTimeRangeInvalid.value || isUploading.value
+)
+
 watch(
   () => props.isOpen,
   (open) => {
@@ -336,6 +346,9 @@ function saveSchedule() {
   if (!newSchedule.value.content.trim()) {
     return
   }
+  if (isScheduleTimeRangeInvalid.value) {
+    return
+  }
 
   // Check if upload is in progress
   if (scheduleFormRef.value?.isUploading()) {
@@ -478,7 +491,8 @@ function handleUploadError(message: string) {
             </button>
           </div>
           <!-- Create/Edit mode: Save/Cancel buttons -->
-          <div v-else-if="isCreateMode || isEditMode" class="flex flex-row gap-2 justify-end">
+          <div v-else-if="isCreateMode || isEditMode" class="flex justify-end">
+            <div class="flex flex-row gap-2 justify-end">
             <button
               @click="cancelEdit"
               class="flex-1 sm:flex-none px-4 py-2 rounded-lg transition btn-outline cursor-pointer"
@@ -487,11 +501,13 @@ function handleUploadError(message: string) {
             </button>
             <button
               @click="saveSchedule"
-              :disabled="isUploading"
+              :disabled="isScheduleSaveDisabled"
+              :aria-label="t('duty.schedule.actions.save')"
               class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             >
               {{ isUploading ? t('duty.common.uploading') : t('duty.schedule.actions.save') }}
             </button>
+            </div>
           </div>
         </div>
   </BaseModal>

--- a/frontend/src/components/duty/ScheduleForm.vue
+++ b/frontend/src/components/duty/ScheduleForm.vue
@@ -63,6 +63,12 @@ const { t } = useI18n()
 
 const fileUploaderRef = ref<InstanceType<typeof FileUploader> | null>(null)
 
+const isTitleMissing = computed(() => !props.form.content.trim())
+const isTimeRangeInvalid = computed(() => {
+  if (!props.form.startDateTime || !props.form.endDateTime) return false
+  return props.form.endDateTime < props.form.startDateTime
+})
+
 function getSessionId() {
   return fileUploaderRef.value?.getSessionId() || null
 }
@@ -100,6 +106,7 @@ defineExpose({
           maxlength="50"
           class="schedule-form__input schedule-form__input--with-counter w-full px-3 py-1.5 sm:py-2 rounded-lg focus:ring-2 focus:ring-dp-accent focus:border-transparent form-control"
           :placeholder="t('duty.schedule.placeholders.title')"
+          :aria-invalid="isTitleMissing"
         />
         <div class="schedule-form__counter pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
           <CharacterCounter :current="form.content.length" :max="50" />
@@ -115,6 +122,8 @@ defineExpose({
           v-model="startTime"
           type="time"
           class="schedule-form__input flex-1 min-w-0 px-2 sm:px-3 py-1.5 sm:py-2 rounded-lg focus:ring-2 focus:ring-dp-accent focus:border-transparent form-control"
+          :class="{ 'schedule-form__input--invalid': isTimeRangeInvalid }"
+          :aria-invalid="isTimeRangeInvalid"
         />
       </div>
       <!-- Edit mode: full datetime (allow changing date) -->
@@ -124,6 +133,8 @@ defineExpose({
           v-model="form.startDateTime"
           type="datetime-local"
           class="schedule-form__input flex-1 min-w-0 px-2 sm:px-3 py-1.5 sm:py-2 rounded-lg focus:ring-2 focus:ring-dp-accent focus:border-transparent form-control"
+          :class="{ 'schedule-form__input--invalid': isTimeRangeInvalid }"
+          :aria-invalid="isTimeRangeInvalid"
         />
       </div>
       <div class="flex items-center gap-2">
@@ -132,6 +143,8 @@ defineExpose({
           v-model="form.endDateTime"
           type="datetime-local"
           class="schedule-form__input flex-1 min-w-0 px-2 sm:px-3 py-1.5 sm:py-2 rounded-lg focus:ring-2 focus:ring-dp-accent focus:border-transparent form-control"
+          :class="{ 'schedule-form__input--invalid': isTimeRangeInvalid }"
+          :aria-invalid="isTimeRangeInvalid"
         />
       </div>
     </div>
@@ -233,6 +246,10 @@ defineExpose({
   border-color: var(--dp-accent-border);
   background-color: var(--dp-bg-secondary);
   opacity: 0.92;
+}
+
+.schedule-form__input--invalid {
+  border-color: var(--dp-warning);
 }
 
 @media (max-width: 639px) {

--- a/frontend/src/components/duty/TodoAddModal.vue
+++ b/frontend/src/components/duty/TodoAddModal.vue
@@ -47,6 +47,8 @@ const { showWarning, showError } = useSwal()
 
 const { t } = useI18n()
 
+const isTitleMissing = computed(() => !title.value.trim())
+
 const statusOptions = computed<Array<{ value: TodoStatus; label: string; icon: typeof ListTodo; colorClass: string }>>(() => [
   { value: 'TODO', label: t('duty.todo.status.todo'), icon: ListTodo, colorClass: 'status-card-todo' },
   { value: 'IN_PROGRESS', label: t('duty.todo.status.inProgress'), icon: Clock, colorClass: 'status-card-in-progress' },
@@ -196,6 +198,7 @@ function onUploadError(message: string) {
           maxlength="50"
           class="form-control"
           :placeholder="t('duty.todo.placeholders.title')"
+          :aria-invalid="isTitleMissing"
         />
       </div>
 
@@ -256,7 +259,7 @@ function onUploadError(message: string) {
       </button>
       <button
         @click="handleSave"
-        :disabled="!title.trim() || isUploading"
+        :disabled="isTitleMissing || isUploading"
         class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
       >
         {{ isUploading ? t('duty.common.uploading') : t('duty.todo.actions.save') }}

--- a/frontend/src/components/duty/TodoDetailModal.vue
+++ b/frontend/src/components/duty/TodoDetailModal.vue
@@ -110,6 +110,9 @@ const selectedTagSummaries = computed(() => {
   })
 })
 
+const isEditTitleMissing = computed(() => !editTitle.value.trim())
+const isEditSaveDisabled = computed(() => isEditTitleMissing.value || isUploading.value)
+
 watch(
   () => props.isOpen,
   async (open) => {
@@ -244,7 +247,10 @@ function cancelEdit() {
 }
 
 function saveEdit() {
-  if (!props.todo || !editTitle.value.trim()) return
+  if (!props.todo) return
+  if (!editTitle.value.trim()) {
+    return
+  }
   if (isUploading.value) {
     showWarning(t('duty.todo.warnings.uploadInProgress'))
     return
@@ -405,6 +411,7 @@ function onUploadError(message: string) {
               type="text"
               maxlength="50"
               class="form-control"
+              :aria-invalid="isEditTitleMissing"
             />
           </div>
 
@@ -523,7 +530,8 @@ function onUploadError(message: string) {
           </div>
         </template>
         <template v-else>
-          <div class="flex flex-row gap-2 justify-end">
+          <div class="flex justify-end">
+            <div class="flex flex-row gap-2 justify-end">
             <button
               @click="cancelEdit"
               class="flex-1 sm:flex-none px-4 py-2 rounded-lg transition btn-outline cursor-pointer"
@@ -532,11 +540,12 @@ function onUploadError(message: string) {
             </button>
             <button
               @click="saveEdit"
-              :disabled="!editTitle.trim() || isUploading"
-              class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 cursor-pointer"
+              :disabled="isEditSaveDisabled"
+              class="flex-1 sm:flex-none px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             >
               {{ isUploading ? t('duty.common.uploading') : t('duty.todo.actions.save') }}
             </button>
+            </div>
           </div>
         </template>
       </div>

--- a/frontend/src/components/team/BatchUploadModal.vue
+++ b/frontend/src/components/team/BatchUploadModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseModal from '@/components/common/BaseModal.vue'
 import { useSwal } from '@/composables/useSwal'
@@ -26,6 +26,21 @@ const batchForm = ref({
   year: new Date().getFullYear(),
   month: new Date().getMonth() + 1,
 })
+const currentYear = new Date().getFullYear()
+const maxYear = currentYear + 1
+
+const isFileMissing = computed(() => !batchForm.value.file)
+const isPeriodInvalid = computed(() => {
+  const year = Number(batchForm.value.year)
+  const month = Number(batchForm.value.month)
+  return !Number.isInteger(year) || !Number.isInteger(month) ||
+    year < currentYear || year > maxYear || month < 1 || month > 12
+})
+const periodFeedbackMessage = computed(() => {
+  if (!isPeriodInvalid.value) return ''
+  return t('team.batchUpload.validation.period')
+})
+const isUploadDisabled = computed(() => props.saving || isFileMissing.value || isPeriodInvalid.value)
 
 watch(() => props.isOpen, (open) => {
   if (!open) return
@@ -50,6 +65,10 @@ function handleFileChange(event: Event) {
 async function uploadBatch() {
   if (!batchForm.value.file) {
     showWarning(t('team.batchUpload.selectFile'))
+    return
+  }
+  if (isPeriodInvalid.value) {
+    showWarning(periodFeedbackMessage.value)
     return
   }
 
@@ -105,6 +124,7 @@ async function uploadBatch() {
           accept=".xlsx"
           @change="handleFileChange"
           class="form-control"
+          :aria-invalid="isFileMissing"
         />
       </div>
 
@@ -116,9 +136,10 @@ async function uploadBatch() {
           <input
             v-model.number="batchForm.year"
             type="number"
-            :min="new Date().getFullYear()"
-            :max="new Date().getFullYear() + 1"
+            :min="currentYear"
+            :max="maxYear"
             class="form-control"
+            :aria-invalid="isPeriodInvalid"
           />
         </div>
         <div>
@@ -131,6 +152,7 @@ async function uploadBatch() {
             min="1"
             max="12"
             class="form-control"
+            :aria-invalid="isPeriodInvalid"
           />
         </div>
       </div>
@@ -139,7 +161,7 @@ async function uploadBatch() {
     <div class="modal-actions modal-actions-end modal-footer-safe">
       <button
         @click="uploadBatch"
-        :disabled="saving || !batchForm.file"
+        :disabled="isUploadDisabled"
         class="px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg font-medium hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 cursor-pointer"
       >
         <Loader2 v-if="saving" class="w-4 h-4 animate-spin" />

--- a/frontend/src/components/team/DutyTypeModal.vue
+++ b/frontend/src/components/team/DutyTypeModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, nextTick, onUnmounted } from 'vue'
+import { computed, ref, watch, nextTick, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseModal from '@/components/common/BaseModal.vue'
 import { useSwal } from '@/composables/useSwal'
@@ -35,6 +35,14 @@ const dutyTypeForm = ref({
   color: defaultDutyColor,
   isDefault: false,
 })
+const trimmedDutyTypeName = computed(() => dutyTypeForm.value.name.trim())
+const hasDuplicateDutyTypeName = computed(() =>
+  props.dutyTypes.some(
+    dt => dt.name === trimmedDutyTypeName.value && dt.id !== dutyTypeForm.value.id
+  )
+)
+const isDutyTypeNameInvalid = computed(() => !trimmedDutyTypeName.value || hasDuplicateDutyTypeName.value)
+const isDutyTypeSaveDisabled = computed(() => props.saving || isDutyTypeNameInvalid.value)
 
 let pickrInstance: Pickr | null = null
 const colorPickerRef = ref<HTMLElement | null>(null)
@@ -120,16 +128,13 @@ function close() {
 }
 
 async function saveDutyType() {
-  if (!dutyTypeForm.value.name) {
+  if (!trimmedDutyTypeName.value) {
     showWarning(t('team.dutyType.warnings.nameRequired'))
     return
   }
 
-  const exists = props.dutyTypes.some(
-    dt => dt.name === dutyTypeForm.value.name && dt.id !== dutyTypeForm.value.id
-  )
-  if (exists) {
-    showWarning(t('team.dutyType.warnings.duplicate', { name: dutyTypeForm.value.name }))
+  if (hasDuplicateDutyTypeName.value) {
+    showWarning(t('team.dutyType.warnings.duplicate', { name: trimmedDutyTypeName.value }))
     return
   }
 
@@ -138,19 +143,19 @@ async function saveDutyType() {
     if (dutyTypeForm.value.isDefault) {
       await teamApi.updateDefaultDuty(
         props.teamId,
-        dutyTypeForm.value.name,
+        trimmedDutyTypeName.value,
         dutyTypeForm.value.color
       )
     } else if (dutyTypeForm.value.id) {
       await teamApi.updateDutyType(props.teamId, {
         id: dutyTypeForm.value.id,
-        name: dutyTypeForm.value.name,
+        name: trimmedDutyTypeName.value,
         color: dutyTypeForm.value.color,
       })
     } else {
       await teamApi.addDutyType(props.teamId, {
         teamId: props.teamId,
-        name: dutyTypeForm.value.name,
+        name: trimmedDutyTypeName.value,
         color: dutyTypeForm.value.color,
       })
     }
@@ -207,6 +212,7 @@ async function saveDutyType() {
           maxlength="10"
           :placeholder="t('team.dutyType.placeholders.name')"
           class="form-control"
+          :aria-invalid="isDutyTypeNameInvalid"
         />
       </div>
 
@@ -235,7 +241,7 @@ async function saveDutyType() {
     <div class="modal-actions modal-actions-end modal-footer-safe">
       <button
         @click="saveDutyType"
-        :disabled="!dutyTypeForm.name.trim()"
+        :disabled="isDutyTypeSaveDisabled"
         class="px-4 py-2 bg-dp-success text-dp-text-on-dark rounded-lg font-medium hover:bg-dp-success-hover transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
       >
         {{ dutyTypeForm.id !== null || dutyTypeForm.isDefault ? t('common.actions.save') : t('common.actions.add') }}

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -1297,6 +1297,9 @@ export default {
       month: 'Month',
       success: 'The duty roster has been uploaded.',
       failed: 'Failed to upload the duty roster.',
+      validation: {
+        period: 'Enter a valid year and month.',
+      },
     },
     dutyType: {
       titleAdd: 'Add duty type',
@@ -1398,6 +1401,7 @@ export default {
     validationFailed: 'The selected image cannot be used.',
     imagesOnly: 'Only image files can be uploaded.',
     readFailed: 'Failed to read the image file.',
+    cropFailed: 'Could not prepare the cropped image. Try choosing the image again.',
     uploadTitle: 'Choose an image',
     uploadHint: 'PNG, JPG, WEBP, and GIF files are supported.',
     maxSize: 'Up to {size}',

--- a/frontend/src/i18n/messages/es.ts
+++ b/frontend/src/i18n/messages/es.ts
@@ -1297,6 +1297,9 @@ export default {
       month: 'Mes',
       success: 'Se ha subido la lista de turnos.',
       failed: 'No se pudo cargar la lista de turnos.',
+      validation: {
+        period: 'Introduce un año y un mes válidos.',
+      },
     },
     dutyType: {
       titleAdd: 'Agregar tipo de turno',
@@ -1398,6 +1401,7 @@ export default {
     validationFailed: 'La imagen seleccionada no se puede utilizar.',
     imagesOnly: 'Sólo se pueden cargar archivos de imágenes.',
     readFailed: 'No se pudo leer el archivo de imagen.',
+    cropFailed: 'No se pudo preparar la imagen recortada. Vuelve a elegir la imagen.',
     uploadTitle: 'Elige una imagen',
     uploadHint: 'Se admiten archivos PNG, JPG, WEBP y GIF.',
     maxSize: 'Hasta {size}',

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -1380,6 +1380,9 @@ export default {
       month: '月',
       success: '勤務表をアップロードしました。',
       failed: '勤務表のアップロードに失敗しました。',
+      validation: {
+        period: '正しい年と月を入力してください。',
+      },
     },
     dutyType: {
       ...en.team.dutyType,
@@ -1483,6 +1486,7 @@ export default {
     validationFailed: '選択した画像は使用できません。',
     imagesOnly: '画像ファイルのみアップロードできます。',
     readFailed: '画像ファイルを読み込めませんでした。',
+    cropFailed: '切り抜いた画像を準備できませんでした。画像をもう一度選択してください。',
     uploadTitle: '画像を選択',
     uploadHint: 'PNG, JPG, WEBP, GIF に対応しています。',
     maxSize: '{size} まで',

--- a/frontend/src/i18n/messages/ko.ts
+++ b/frontend/src/i18n/messages/ko.ts
@@ -1297,6 +1297,9 @@ export default {
       month: '월',
       success: '근무표 업로드가 완료되었습니다.',
       failed: '근무표 업로드에 실패했습니다.',
+      validation: {
+        period: '올바른 연도와 월을 입력해주세요.',
+      },
     },
     dutyType: {
       titleAdd: '근무 유형 추가',
@@ -1398,6 +1401,7 @@ export default {
     validationFailed: '선택한 이미지를 사용할 수 없습니다.',
     imagesOnly: '이미지 파일만 업로드할 수 있습니다.',
     readFailed: '이미지 파일을 읽지 못했습니다.',
+    cropFailed: '자른 이미지를 준비하지 못했습니다. 이미지를 다시 선택해주세요.',
     uploadTitle: '이미지 선택',
     uploadHint: 'PNG, JPG, WEBP, GIF 파일을 지원합니다.',
     maxSize: '최대 {size}',

--- a/frontend/src/i18n/messages/zh.ts
+++ b/frontend/src/i18n/messages/zh.ts
@@ -1297,6 +1297,9 @@ export default {
       month: '月份',
       success: '值班表已上传。',
       failed: '上传值班表失败。',
+      validation: {
+        period: '请输入有效的年份和月份。',
+      },
     },
     dutyType: {
       titleAdd: '添加班次类型',
@@ -1398,6 +1401,7 @@ export default {
     validationFailed: '无法使用所选图像。',
     imagesOnly: '只能上传图像文件。',
     readFailed: '无法读取图像文件。',
+    cropFailed: '无法准备裁剪后的图片。请重新选择图片。',
     uploadTitle: '选择图像',
     uploadHint: '支持 PNG、JPG、WEBP 和 GIF 文件。',
     maxSize: '最多 {size}',

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -404,6 +404,18 @@ html.dark {
     background-color: var(--dp-bg-tertiary);
 }
 
+.form-control[aria-invalid="true"],
+.form-control-neutral[aria-invalid="true"],
+.form-control-card[aria-invalid="true"] {
+    border-color: var(--dp-warning);
+}
+
+.form-control[aria-invalid="true"]:focus,
+.form-control-neutral[aria-invalid="true"]:focus,
+.form-control-card[aria-invalid="true"]:focus {
+    --tw-ring-color: var(--dp-warning);
+}
+
 .form-control-neutral {
     @apply w-full px-3 py-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-dp-text-primary focus:border-transparent;
     background-color: var(--dp-bg-input);

--- a/frontend/src/views/admin/AdminDashboardView.vue
+++ b/frontend/src/views/admin/AdminDashboardView.vue
@@ -70,6 +70,7 @@ const passwordTargetMember = ref<{ id: number; name: string } | null>(null)
 const newPassword = ref('')
 const confirmPassword = ref('')
 const passwordError = ref('')
+const changingPassword = ref(false)
 const showMemberDetailModal = ref(false)
 const selectedMemberId = ref<number | null>(null)
 const selectedMemberDetail = ref<AdminMemberDetailDto | null>(null)
@@ -81,6 +82,22 @@ const selectedMemberForDetail = computed(() => {
   if (selectedMemberId.value == null) return null
   return members.value.find(member => member.id === selectedMemberId.value) ?? null
 })
+
+const adminPasswordSubmitHint = computed(() => {
+  if (!newPassword.value || !confirmPassword.value) {
+    return t('admin.dashboard.password.validation.required')
+  }
+  if (newPassword.value.length < 8) {
+    return t('admin.dashboard.password.validation.min')
+  }
+  if (newPassword.value !== confirmPassword.value) {
+    return t('admin.dashboard.password.validation.mismatch')
+  }
+  return ''
+})
+const isAdminPasswordSubmitDisabled = computed(() =>
+  changingPassword.value || !!adminPasswordSubmitHint.value
+)
 
 function openPasswordModal(member: { id: number; name: string }) {
   passwordTargetMember.value = member
@@ -94,8 +111,6 @@ function closePasswordModal() {
   showPasswordModal.value = false
   passwordTargetMember.value = null
 }
-
-const changingPassword = ref(false)
 
 async function handleChangePassword() {
   if (!newPassword.value || !confirmPassword.value) {
@@ -510,8 +525,8 @@ onMounted(async () => {
         </button>
         <button
           @click="handleChangePassword"
-          :disabled="changingPassword"
-          class="px-4 py-2 text-sm font-medium text-dp-text-on-dark bg-dp-surface-strong hover:bg-dp-surface-strong-hover rounded-lg transition disabled:opacity-50 flex items-center gap-2 cursor-pointer"
+          :disabled="isAdminPasswordSubmitDisabled"
+          class="px-4 py-2 text-sm font-medium text-dp-text-on-dark bg-dp-surface-strong hover:bg-dp-surface-strong-hover rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 cursor-pointer"
         >
           <Loader2 v-if="changingPassword" class="w-4 h-4 animate-spin" />
           {{ changingPassword ? t('admin.dashboard.password.changing') : t('admin.dashboard.password.change') }}

--- a/frontend/src/views/admin/AdminTeamListView.vue
+++ b/frontend/src/views/admin/AdminTeamListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
@@ -46,6 +46,12 @@ const newTeamDescription = ref('')
 const nameCheckResult = ref<TeamNameCheckResult | null>(null)
 const isCheckingName = ref(false)
 const isCreating = ref(false)
+const newTeamNameFeedbackId = 'new-team-name-feedback'
+const trimmedNewTeamName = computed(() => newTeamName.value.trim())
+const trimmedNewTeamDescription = computed(() => newTeamDescription.value.trim())
+const isCreateTeamDisabled = computed(() =>
+  nameCheckResult.value !== 'OK' || !trimmedNewTeamDescription.value || isCreating.value
+)
 
 // Fetch teams from API
 async function fetchTeams() {
@@ -75,18 +81,18 @@ function closeNewTeamModal() {
 }
 
 async function checkTeamName() {
-  if (newTeamName.value.length < 2) {
+  if (trimmedNewTeamName.value.length < 2) {
     nameCheckResult.value = 'TOO_SHORT'
     return
   }
-  if (newTeamName.value.length > 20) {
+  if (trimmedNewTeamName.value.length > 20) {
     nameCheckResult.value = 'TOO_LONG'
     return
   }
 
   isCheckingName.value = true
   try {
-    const response = await adminApi.checkTeamName(newTeamName.value)
+    const response = await adminApi.checkTeamName(trimmedNewTeamName.value)
     nameCheckResult.value = response.data
   } catch (error) {
     console.error('Failed to check team name:', error)
@@ -113,13 +119,13 @@ function getNameCheckMessage(): string {
 
 async function handleCreateTeam() {
   if (nameCheckResult.value !== 'OK') return
-  if (!newTeamDescription.value) return
+  if (!trimmedNewTeamDescription.value) return
 
   isCreating.value = true
   try {
     const response = await adminApi.createTeam({
-      name: newTeamName.value,
-      description: newTeamDescription.value,
+      name: trimmedNewTeamName.value,
+      description: trimmedNewTeamDescription.value,
     })
     toastSuccess(t('admin.teamList.messages.createSuccess'))
     closeNewTeamModal()
@@ -442,11 +448,13 @@ onMounted(() => {
               minlength="2"
               class="form-control-neutral flex-1"
               :placeholder="t('admin.teamList.modal.namePlaceholder')"
+              :aria-invalid="!trimmedNewTeamName || nameCheckResult === 'TOO_SHORT' || nameCheckResult === 'TOO_LONG' || nameCheckResult === 'DUPLICATED'"
+              :aria-describedby="nameCheckResult ? newTeamNameFeedbackId : undefined"
               @input="nameCheckResult = null"
             />
             <button
               @click="checkTeamName"
-              :disabled="isCheckingName"
+              :disabled="isCheckingName || trimmedNewTeamName.length < 2"
               class="px-4 py-2 text-sm font-medium text-dp-text-on-dark bg-dp-accent hover:bg-dp-accent-hover rounded-lg transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               <Loader2 v-if="isCheckingName" class="w-4 h-4 animate-spin" />
@@ -455,6 +463,7 @@ onMounted(() => {
           </div>
           <p
             v-if="nameCheckResult"
+            :id="newTeamNameFeedbackId"
             class="mt-1 text-sm flex items-center gap-1"
             :class="nameCheckResult === 'OK' ? 'text-dp-success' : 'text-dp-danger'"
           >
@@ -474,13 +483,14 @@ onMounted(() => {
             maxlength="50"
             class="form-control-neutral"
             :placeholder="t('admin.teamList.modal.descriptionPlaceholder')"
+            :aria-invalid="!trimmedNewTeamDescription"
           />
         </div>
       </div>
       <div class="modal-actions modal-actions-end modal-footer-safe">
         <button
           @click="handleCreateTeam"
-          :disabled="nameCheckResult !== 'OK' || !newTeamDescription || isCreating"
+          :disabled="isCreateTeamDisabled"
           class="px-4 py-2 text-sm font-medium text-dp-text-on-dark bg-dp-accent hover:bg-dp-accent-hover rounded-lg transition disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer flex items-center gap-2"
         >
           <Loader2 v-if="isCreating" class="w-4 h-4 animate-spin" />

--- a/frontend/src/views/member/MemberView.vue
+++ b/frontend/src/views/member/MemberView.vue
@@ -497,6 +497,23 @@ const passwordErrors = ref({
   newPassword: '',
   confirmPassword: '',
 })
+const changingPassword = ref(false)
+const passwordSubmitHint = computed(() => {
+  if (!passwordForm.value.currentPassword) return t('member.password.validation.currentRequired')
+  if (!passwordForm.value.newPassword) return t('member.password.validation.newRequired')
+  if (passwordForm.value.newPassword.length < 8 || passwordForm.value.newPassword.length > 20) {
+    return t('member.password.validation.length')
+  }
+  if (passwordForm.value.currentPassword === passwordForm.value.newPassword) {
+    return t('member.password.validation.sameAsCurrent')
+  }
+  if (!passwordForm.value.confirmPassword) return t('member.password.validation.confirmRequired')
+  if (passwordForm.value.newPassword !== passwordForm.value.confirmPassword) {
+    return t('member.password.validation.mismatch')
+  }
+  return ''
+})
+const isPasswordSubmitDisabled = computed(() => changingPassword.value || !!passwordSubmitHint.value)
 
 function openPasswordModal() {
   passwordForm.value = { currentPassword: '', newPassword: '', confirmPassword: '' }
@@ -534,8 +551,6 @@ function validatePasswordForm(): boolean {
 
   return isValid
 }
-
-const changingPassword = ref(false)
 
 async function changePassword() {
   if (!validatePasswordForm()) return
@@ -1090,8 +1105,8 @@ onMounted(async () => {
       <div class="modal-actions modal-footer-safe sm:px-6 sm:py-6">
         <button
           @click="changePassword"
-          :disabled="changingPassword"
-          class="flex-1 px-4 py-3 sm:py-2 min-h-11 bg-dp-accent hover:bg-dp-accent-hover rounded-lg text-dp-text-on-dark font-medium transition disabled:opacity-50 flex items-center justify-center gap-2"
+          :disabled="isPasswordSubmitDisabled"
+          class="flex-1 px-4 py-3 sm:py-2 min-h-11 bg-dp-accent hover:bg-dp-accent-hover rounded-lg text-dp-text-on-dark font-medium transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
         >
           <Loader2 v-if="changingPassword" class="w-4 h-4 animate-spin" />
           {{ changingPassword ? t('member.password.submitting') : t('member.password.submit') }}

--- a/frontend/src/views/team/TeamView.vue
+++ b/frontend/src/views/team/TeamView.vue
@@ -103,6 +103,15 @@ const scheduleForm = ref({
   startDate: '',
   endDate: '',
 })
+const isTeamScheduleTitleMissing = computed(() => !scheduleForm.value.content.trim())
+const isTeamScheduleDateRangeInvalid = computed(() => {
+  const { startDate, endDate } = scheduleForm.value
+  if (!startDate || !endDate) return true
+  return endDate < startDate
+})
+const isTeamScheduleSaveDisabled = computed(() =>
+  saving.value || isTeamScheduleTitleMissing.value || isTeamScheduleDateRangeInvalid.value
+)
 
 // Load calendar structure from backend API (cached)
 async function loadCalendar() {
@@ -343,7 +352,10 @@ function closeScheduleModal() {
 }
 
 async function saveSchedule() {
-  if (!team.value || !scheduleForm.value.content.trim()) return
+  if (!team.value) return
+  if (isTeamScheduleTitleMissing.value || isTeamScheduleDateRangeInvalid.value) {
+    return
+  }
 
   saving.value = true
   const isNew = !scheduleForm.value.id
@@ -637,6 +649,7 @@ onMounted(() => {
             maxlength="50"
             class="form-control"
             :placeholder="t('team.view.schedule.modal.contentPlaceholder')"
+            :aria-invalid="isTeamScheduleTitleMissing"
           />
         </div>
 
@@ -671,7 +684,9 @@ onMounted(() => {
             <input
               v-model="scheduleForm.endDate"
               type="date"
+              :min="scheduleForm.startDate"
               class="form-control"
+              :aria-invalid="isTeamScheduleDateRangeInvalid"
             />
           </div>
         </div>
@@ -680,7 +695,7 @@ onMounted(() => {
       <div class="modal-actions modal-actions-end modal-footer-safe">
         <button
           @click="saveSchedule"
-          :disabled="saving || !scheduleForm.content.trim()"
+          :disabled="isTeamScheduleSaveDisabled"
           class="px-4 py-2 bg-dp-accent text-dp-text-on-dark rounded-lg font-medium hover:bg-dp-accent-hover transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 cursor-pointer"
         >
           <Loader2 v-if="saving" class="w-4 h-4 animate-spin" />


### PR DESCRIPTION
## Summary
- Disable modal submit actions when required fields are empty or invalid.
- Keep missing required fields visually simple with border-only invalid states instead of extra helper copy.
- Surface profile image crop failures instead of closing the modal silently.

## Changes
- Added invalid-state handling for schedule, D-Day, todo, team schedule, batch upload, duty type, admin team creation, member password, and admin password modals.
- Disabled friend search when the keyword is empty or a search is already loading.
- Added shared `aria-invalid` form-control border styling.
- Added localized messages for batch upload period validation and image crop failures.
- Adjusted GitHub release link formatting in the release preparation script.

## Commits
- 87121858 fix: disable invalid modal submissions
- e67c60cc fix: format release pull request link

## Verification
- [x] `cd frontend && npm run build`